### PR TITLE
Fix grammar mistake in an error message in divert.

### DIFF
--- a/src/divert.c
+++ b/src/divert.c
@@ -87,7 +87,7 @@ int divertStart(const char *filter, char buf[]) {
             strcpy(buf, "Failed to start filtering : filter syntax error.");
         } else {
             sprintf(buf, "Failed to start filtering : failed to open device (code:%lu).\n"
-                "Make sure to you have run clumsy as Administrator.", lastError);
+                "Make sure you run clumsy as Administrator.", lastError);
         }
         return FALSE;
     }


### PR DESCRIPTION
I noticed a typo when running clumsy, so I decided to change it for your convenience.
