### PR TITLE
Fix mixed-content issue for stylesheet, and upgrade some links to HTTPS

### DIFF
--- a/cn/download.html
+++ b/cn/download.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, 在 Windows Vista / Windows 7 下模拟劣化网络环境(网络延迟，掉包，重发)的小工具。</title>
-    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui-s.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">

--- a/cn/download.html
+++ b/cn/download.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, 在 Windows Vista / Windows 7 下模拟劣化网络环境(网络延迟，掉包，重发)的小工具。</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">
@@ -70,7 +70,7 @@ mingw32-make -C build CC=gcc config=release64
         <p>
         以下是 clumsy 依赖的其他库和程序。
         <ul class="textlist">
-        <li><a href="http://reqrypt.org/windivert.html">WinDivert</a> 把复杂而且文档少的 Windows Filtering Platform 封装成了十来个函数。没有这个本项目基本没法做。</li>
+        <li><a href="https://reqrypt.org/windivert.html">WinDivert</a> 把复杂而且文档少的 Windows Filtering Platform 封装成了十来个函数。没有这个本项目基本没法做。</li>
         <li><a href="http://www.tecgraf.puc-rio.br/iup/">IUP Portable User Interface</a> ANSI C 跨平台<i>原生</i> UI 库。功能齐全上手快。</li>
         <li><a href="http://www.cockos.com/licecap/">LICEcap</a> 开源免费的 gif 截屏工具。</li>
         </ul>

--- a/cn/index.html
+++ b/cn/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, 在 Windows Vista / Windows 7 下模拟劣化网络环境(网络延迟，掉包，重发)的小工具。</title>
-    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui-s.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">

--- a/cn/index.html
+++ b/cn/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, 在 Windows Vista / Windows 7 下模拟劣化网络环境(网络延迟，掉包，重发)的小工具。</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">
@@ -33,7 +33,7 @@
         </p>
         <h4>简介</h4>
         <p>
-            利用封装 Winodws Filtering Platform 的<a href="http://reqrypt.org/windivert.html">WinDivert 库</a>, clumsy 能实时的将系统接收和发出的网络数据包拦截下来，人工的造成延迟，掉包和篡改操作后再进行发送。无论你是要重现网络异常造成的程序错误，还是评估你的应用程序在不良网络状况下的表现，clumsy 都能让你在不需要额外添加代码的情况下，在系统层次帮你达到想要的效果：
+            利用封装 Winodws Filtering Platform 的<a href="https://reqrypt.org/windivert.html">WinDivert 库</a>, clumsy 能实时的将系统接收和发出的网络数据包拦截下来，人工的造成延迟，掉包和篡改操作后再进行发送。无论你是要重现网络异常造成的程序错误，还是评估你的应用程序在不良网络状况下的表现，clumsy 都能让你在不需要额外添加代码的情况下，在系统层次帮你达到想要的效果：
         </p>
         <span>特色：</span>
         <ul class="textlist">

--- a/cn/manual.html
+++ b/cn/manual.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, 在 Windows Vista / Windows 7 下模拟劣化网络环境(网络延迟，掉包，重发)的小工具。</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">
@@ -47,7 +47,7 @@
         <ol class="textlist">
             <li>回送的输入数据包(Loopback inbound packets)无法被重新注入。<br>
             仔细想想你就会发现我们没有很好的方法来区分一个回送数据包到底是被发出还是被接收到，因为它们的目标和来源 IP 地址都是本机。事实上 clumsy 底层的 WinDivert，以及其基于的
-            <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa366510(v=vs.85).aspx">Windows Filtering Platform</a> 把所有的回送数据包统统认为是<i>输出 (Outbound) </i>数据包。这里需要记住的是，当你在本机上处理回送数据包的时候，你不能把 "inbound" 设置在 filter 条件中，最简单的方法就是在条件中简单的加上 "outbound"。另一件容易出问题的事情是，你本机的 IP 不仅仅只有 127.0.0.1 一个，还有类似路由器分配给你机器的 IP 也是属于你的本机 IP。
+            <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366510(v=vs.85).aspx">Windows Filtering Platform</a> 把所有的回送数据包统统认为是<i>输出 (Outbound) </i>数据包。这里需要记住的是，当你在本机上处理回送数据包的时候，你不能把 "inbound" 设置在 filter 条件中，最简单的方法就是在条件中简单的加上 "outbound"。另一件容易出问题的事情是，你本机的 IP 不仅仅只有 127.0.0.1 一个，还有类似路由器分配给你机器的 IP 也是属于你的本机 IP。
             </li>
             <li>回送数据包会被处理两次。<br>
             因为所有的回送数据包都被认为是输出数据包，clumsy 会重复处理它们<i>两次</i>。一次是在发出的时候，一次是在接受到的时候。一个简单的例子是简单的把 filter 设置为 outbound，然后在 clumsy 中设置 500ms 的延迟并开启，之后在命令行里 ping localhost。这时你会发现延迟是 1000ms。当然你可以仔细的设置 filter 条件通过设置端口来只捕捉一部分的回送数据包，但是这样会比较麻烦。最简单的做法就是记住这个问题，然后设置参数的时候做相应的计算。
@@ -85,7 +85,7 @@
 
         <h4>Filter 语法</h4>
         <p>
-        这里 filter 中提供的语句会被直接作为参数提供给 WinDivert。语法在 <a href="http://reqrypt.org/windivert-doc.html#filter_language">WinDivert 的文档</a>中有详细的描述。如果你写过一点程序你会发现这个语法跟你放在 <i>if</i> 里面的判断表达式非常类似。你可以用 <i>and</i>, <i>or</i>, <i>not</i> 和 <i>括号</i> 来表达简单的逻辑规则。类似 <i>=</i>, <i>!=</i>, <i>&lsaquo;</i>, <i>&rsaquo;</i> 的操作符也可以被使用。下面是 filter 中可以使用的变量的列表(直接拷贝自 WinDivert 的文档)。你也可以通过以预设的 filter 作为例子参考。
+        这里 filter 中提供的语句会被直接作为参数提供给 WinDivert。语法在 <a href="https://reqrypt.org/windivert-doc.html#filter_language">WinDivert 的文档</a>中有详细的描述。如果你写过一点程序你会发现这个语法跟你放在 <i>if</i> 里面的判断表达式非常类似。你可以用 <i>and</i>, <i>or</i>, <i>not</i> 和 <i>括号</i> 来表达简单的逻辑规则。类似 <i>=</i>, <i>!=</i>, <i>&lsaquo;</i>, <i>&rsaquo;</i> 的操作符也可以被使用。下面是 filter 中可以使用的变量的列表(直接拷贝自 WinDivert 的文档)。你也可以通过以预设的 filter 作为例子参考。
         </p>
         <div>
             <table border="1" cellpadding="1" class="textlist" style="width:460px; margin:0 auto;">
@@ -138,7 +138,7 @@
         </p>
         <p>
             <strong>在 Windows Server 2008 上报错。</strong><br>
-            安装<a href="http://support.microsoft.com/kb/2761494">这个系统补丁</a>可以解决这个问题。 参见这个 <a href="https://github.com/jagt/clumsy/issues/14#issuecomment-72691983">issue</a>。
+            安装<a href="https://support.microsoft.com/kb/2761494">这个系统补丁</a>可以解决这个问题。 参见这个 <a href="https://github.com/jagt/clumsy/issues/14#issuecomment-72691983">issue</a>。
         </p>
 
         <hr>

--- a/cn/manual.html
+++ b/cn/manual.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, 在 Windows Vista / Windows 7 下模拟劣化网络环境(网络延迟，掉包，重发)的小工具。</title>
-    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui-s.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">

--- a/download.html
+++ b/download.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, an utility for simulating broken network for Windows Vista / Windows 7 and above</title>
-    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui-s.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">

--- a/download.html
+++ b/download.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, an utility for simulating broken network for Windows Vista / Windows 7 and above</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">
@@ -67,7 +67,7 @@ mingw32-make -C build CC=gcc config=release64
         <p>
         Here's a list of things used to build clumsy. 
         <ul class="textlist">
-        <li><a href="http://reqrypt.org/windivert.html">WinDivert</a> used to handle the magical Windows packet capturing/reinjecting. It installs network drivers at runtime and removes it when closing, encapsuled the underdocumented Windows Filtering Platform, does a bunch of things that non Windows developers can hardly figure out how in years. WinDivert jam all these into a handful of functions for you to use for free, while similar commercial solution costs thousands.</li>
+        <li><a href="https://reqrypt.org/windivert.html">WinDivert</a> used to handle the magical Windows packet capturing/reinjecting. It installs network drivers at runtime and removes it when closing, encapsuled the underdocumented Windows Filtering Platform, does a bunch of things that non Windows developers can hardly figure out how in years. WinDivert jam all these into a handful of functions for you to use for free, while similar commercial solution costs thousands.</li>
         <li><a href="http://www.tecgraf.puc-rio.br/iup/">IUP Portable User Interface</a> ANSI C library to build <i>native</i> cross platform GUI. It's so wonderfully designed and you can pick it up in a single day, and it's a full funcion GUI toolkit in C. Think about it.</li>
         <li><a href="http://www.cockos.com/licecap/">LICEcap</a> free and open source gif capturing that just works.</li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, an utility for simulating broken network for Windows Vista / Windows 7 and above</title>
-    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui-s.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, an utility for simulating broken network for Windows Vista / Windows 7 and above</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">
@@ -33,7 +33,7 @@
         </p>
         <h4>Introduction</h4>
         <p>
-            Leveraging the awesome <a href="http://reqrypt.org/windivert.html">WinDivert library</a>, clumsy stops living network packets and capture them, lag/drop/tamper/.. the packets on demand, then send them away. Whether you want to track down weird bugs related to broken network, or evaluate your application on poor connections, clumsy will come in handy:
+            Leveraging the awesome <a href="https://reqrypt.org/windivert.html">WinDivert library</a>, clumsy stops living network packets and capture them, lag/drop/tamper/.. the packets on demand, then send them away. Whether you want to track down weird bugs related to broken network, or evaluate your application on poor connections, clumsy will come in handy:
         </p>
         <ul class="textlist">
             <li>No installation.</li>

--- a/manual.html
+++ b/manual.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, an utility for simulating broken network for Windows Vista / Windows 7 and above</title>
-    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui-s.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">

--- a/manual.html
+++ b/manual.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8"> 
     <title>clumsy, an utility for simulating broken network for Windows Vista / Windows 7 and above</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.3.0/pure-min.css">
+    <link rel="stylesheet" href="https://yui.yahooapis.com/pure/0.3.0/pure-min.css">
     <link rel="stylesheet" href="layout.css">
 <!--[if lte IE 8]>
     <link rel="stylesheet" href="ie8.css">
@@ -46,7 +46,7 @@
         </p>
         <ol class="textlist">
             <li>Loopback inbound packets can't be captured or reinjected.<br>
-            When you think about it, it's really difficult to tell it's an inbound or outbound packets when you're sending packets from the computer to itself. In fact the underlying <a href="http://msdn.microsoft.com/en-us/library/windows/desktop/aa366510(v=vs.85).aspx">Windows Filtering Platform</a> seems to classify all loopback packets as <i>outbound</i>. The thing to remember is that when you're processing on loopback packets, you can't have "inbound" in your filter. It's important to know that your computer may have IPs other than 127.0.0.1, like an intranet IP allocated by your router. These are also considered loopback packets.
+            When you think about it, it's really difficult to tell it's an inbound or outbound packets when you're sending packets from the computer to itself. In fact the underlying <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366510(v=vs.85).aspx">Windows Filtering Platform</a> seems to classify all loopback packets as <i>outbound</i>. The thing to remember is that when you're processing on loopback packets, you can't have "inbound" in your filter. It's important to know that your computer may have IPs other than 127.0.0.1, like an intranet IP allocated by your router. These are also considered loopback packets.
             </li>
             <li>Loopback packets are captured twice.<br>
             Since we don't have inbound loopback packets, all loopback packets are considered as outbound. So clumsy will process them <i>twice</i>: first time is when sending, and second time when receiving. A simple example is that when filter is simply "outbound", and apply a lag of 500ms. When you ping localhost, it would be a lag of 1000ms. You can work around it by specify destination port and things like this. But it would be easier to just keep this in mind and be careful when setting the parameters.
@@ -85,7 +85,7 @@
 
         <h4>Filter Syntax</h4>
         <p>
-        The filtering text is directly feed to WinDivert. The syntax is well documented <a href="http://reqrypt.org/windivert-doc.html#filter_language">here</a>. If you've programmed in any language, it should be looks very familar to what you put in the <i>if</i> condition. You can use <i>and</i>, <i>or</i>, <i>not</i> and <i>parentheses</i> to build the logic expression. Ops like <i>=</i>, <i>!=</i>, <i>&lsaquo;</i>, <i>&rsaquo;</i> are also provided. A list of available fields from WinDivert documentation is attached as below. You can also refer to the presets for example.
+        The filtering text is directly feed to WinDivert. The syntax is well documented <a href="https://reqrypt.org/windivert-doc.html#filter_language">here</a>. If you've programmed in any language, it should be looks very familar to what you put in the <i>if</i> condition. You can use <i>and</i>, <i>or</i>, <i>not</i> and <i>parentheses</i> to build the logic expression. Ops like <i>=</i>, <i>!=</i>, <i>&lsaquo;</i>, <i>&rsaquo;</i> are also provided. A list of available fields from WinDivert documentation is attached as below. You can also refer to the presets for example.
         </p>
         <div>
             <table border="1" cellpadding="1" class="textlist" style="width:460px; margin:0 auto;">
@@ -138,7 +138,7 @@
         </p>
         <p>
             <strong>Failed to start on Windows Server 2008.</strong><br>
-            This can be fixed by <a href="http://support.microsoft.com/kb/2761494">installing an patch from Microsoft</a>. See <a href="https://github.com/jagt/clumsy/issues/14#issuecomment-72691983">this</a>.
+            This can be fixed by <a href="https://support.microsoft.com/kb/2761494">installing an patch from Microsoft</a>. See <a href="https://github.com/jagt/clumsy/issues/14#issuecomment-72691983">this</a>.
         </p>
 
         <hr>


### PR DESCRIPTION
This makes the navigation menu display properly on https://jagt.github.io/clumsy/ for HTTPS Everywhere users.

Also, I changed some links to point to HTTPS (namely [support.microsoft.com](https://support.microsoft.com), [msdn.microsoft.com](https://msdn.microsoft.com) and [reqrypt.org](https://reqrypt.org)) since those sites already redirect HTTP to HTTPS anyway.