### PR TITLE
Scheduling rework

### DIFF
--- a/src/cap.c
+++ b/src/cap.c
@@ -88,7 +88,7 @@ static void capCloseDown(PacketNode *head, PacketNode *tail) {
     endTimePeriod();
 }
 
-static short capProcess(PacketNode *head, PacketNode *tail) {
+static short capProcess(PacketNode *head, PacketNode *tail, short *delay) {
     short capped = FALSE;
     PacketNode *pac, *pacTmp, *oldLast;
     DWORD curTick = timeGetTime();
@@ -113,7 +113,7 @@ static short capProcess(PacketNode *head, PacketNode *tail) {
 
         if (totalBytes > bytesCapped) {
             break;
-        }   
+        }
     }
 
     // process live packets
@@ -130,7 +130,7 @@ static short capProcess(PacketNode *head, PacketNode *tail) {
         if (totalBytes > bytesCapped) {
             int capCnt = 0;
             capped = TRUE;
-            // buffer from pac to head 
+            // buffer from pac to head
             while (bufSize < KEEP_AT_MOST && pac != head) {
                 pacTmp = pac->prev;
                 insertAfter(popNode(pac), bufHead);
@@ -154,6 +154,9 @@ static short capProcess(PacketNode *head, PacketNode *tail) {
             pac = pac->prev;
         }
     }
+
+    // We don't mind when we're next scheduled.
+    *delay = 1000;
 
     return capped;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -116,12 +116,12 @@ typedef struct {
     Ihandle* (*setupUIFunc)(); // return hbox as controls group
     void (*startUp)(); // called when starting up the module
     void (*closeDown)(PacketNode *head, PacketNode *tail); // called when starting up the module
-    short (*process)(PacketNode *head, PacketNode *tail);
+    short (*process)(PacketNode *head, PacketNode *tail, short *delay);
     /*
      * Flags used during program excution. Need to be re initialized on each run
      */
     short lastEnabled; // if it is enabled on last run
-    short processTriggered; // whether this module has been triggered in last step 
+    short processTriggered; // whether this module has been triggered in last step
     Ihandle *iconHandle; // store the icon to be updated
 } Module;
 
@@ -135,7 +135,7 @@ extern Module resetModule;
 extern Module capModule;
 extern Module* modules[MODULE_CNT]; // all modules in a list
 
-// status for sending packets, 
+// status for sending packets,
 #define SEND_STATUS_NONE 0
 #define SEND_STATUS_SEND 1
 #define SEND_STATUS_FAIL -1

--- a/src/drop.c
+++ b/src/drop.c
@@ -53,7 +53,7 @@ static void dropCloseDown(PacketNode *head, PacketNode *tail) {
     LOG("drop disabled");
 }
 
-static short dropProcess(PacketNode *head, PacketNode* tail) {
+static short dropProcess(PacketNode *head, PacketNode* tail, short *delay) {
     int dropped = 0;
     while (head->next != tail) {
         PacketNode *pac = head->next;
@@ -68,6 +68,9 @@ static short dropProcess(PacketNode *head, PacketNode* tail) {
             head = head->next;
         }
     }
+
+    // We don't mind when we're next scheduled.
+    *delay = 1000;
 
     return dropped > 0;
 }

--- a/src/duplicate.c
+++ b/src/duplicate.c
@@ -65,7 +65,7 @@ static void dupCloseDown(PacketNode *head, PacketNode *tail) {
     LOG("dup disabled");
 }
 
-static short dupProcess(PacketNode *head, PacketNode *tail) {
+static short dupProcess(PacketNode *head, PacketNode *tail, short *delay) {
     short duped = FALSE;
     PacketNode *pac = head->next;
     while (pac != tail) {
@@ -81,6 +81,10 @@ static short dupProcess(PacketNode *head, PacketNode *tail) {
         }
         pac = pac->next;
     }
+
+    // We don't mind when we're next scheduled.
+    *delay = 1000;
+
     return duped;
 }
 

--- a/src/lag.c
+++ b/src/lag.c
@@ -83,7 +83,7 @@ static void lagCloseDown(PacketNode *head, PacketNode *tail) {
     endTimePeriod();
 }
 
-static short lagProcess(PacketNode *head, PacketNode *tail) {
+static short lagProcess(PacketNode *head, PacketNode *tail, short *delay) {
     DWORD currentTime = timeGetTime();
     PacketNode *pac = tail->prev;
     // pick up all packets and fill in the current time
@@ -98,6 +98,7 @@ static short lagProcess(PacketNode *head, PacketNode *tail) {
     }
 
     // try sending overdue packets from buffer tail
+    *delay = 1000;
     while (!isBufEmpty()) {
         PacketNode *pac = bufTail->prev;
         if (currentTime > pac->timestamp + lagTime) {
@@ -106,6 +107,7 @@ static short lagProcess(PacketNode *head, PacketNode *tail) {
             LOG("Send lagged packets.");
         } else {
             LOG("Sent some lagged packets, still have %d in buf", bufSize);
+            *delay = pac->timestamp + lagTime - currentTime;
             break;
         }
     }

--- a/src/ood.c
+++ b/src/ood.c
@@ -4,7 +4,7 @@
 #define NAME "ood"
 // keep a picked packet at most for KEEP_TURNS_MAX steps, or if there's no following
 // one, it will just be sent
-#define KEEP_TURNS_MAX 10 
+#define KEEP_TURNS_MAX 10
 
 static Ihandle *inboundCheckbox, *outboundCheckbox, *chanceInput;
 
@@ -100,7 +100,7 @@ static void swapNode(PacketNode *a, PacketNode *b) {
     }
 }
 
-static short oodProcess(PacketNode *head, PacketNode *tail) {
+static short oodProcess(PacketNode *head, PacketNode *tail, short *delay) {
     if (oodPacket != NULL) {
         if (!isListEmpty() || --giveUpCnt == 0) {
             LOG("Ooo sent direction %s, is giveup %s", BOUND_TEXT(oodPacket->addr.Direction), giveUpCnt ? "NO" : "YES");
@@ -135,6 +135,9 @@ static short oodProcess(PacketNode *head, PacketNode *tail) {
             return TRUE;
         }
     }
+
+    // We don't mind when we're next scheduled.
+    *delay = 1000;
 
     return FALSE;
 }

--- a/src/reset.c
+++ b/src/reset.c
@@ -72,7 +72,7 @@ static void resetCloseDown(PacketNode *head, PacketNode *tail) {
     InterlockedExchange16(&setNextCount, 0);
 }
 
-static short resetProcess(PacketNode *head, PacketNode *tail) {
+static short resetProcess(PacketNode *head, PacketNode *tail, short *delay) {
     short reset = FALSE;
     PacketNode *pac = head->next;
     while (pac != tail) {
@@ -104,9 +104,13 @@ static short resetProcess(PacketNode *head, PacketNode *tail) {
                 }
             }
         }
-        
+
         pac = pac->next;
     }
+
+    // We don't mind when we're next scheduled.
+    *delay = 1000;
+
     return reset;
 }
 

--- a/src/tamper.c
+++ b/src/tamper.c
@@ -83,7 +83,7 @@ static INLINE_FUNCTION void tamper_buf(char *buf, UINT len) {
     }
 }
 
-static short tamperProcess(PacketNode *head, PacketNode *tail) {
+static short tamperProcess(PacketNode *head, PacketNode *tail, short *delay) {
     short tampered = FALSE;
     PacketNode *pac = head->next;
     while (pac != tail) {
@@ -92,7 +92,7 @@ static short tamperProcess(PacketNode *head, PacketNode *tail) {
             char *data = NULL;
             UINT dataLen = 0;
             if (WinDivertHelperParsePacket(pac->packet, pac->packetLen, NULL, NULL, NULL,
-                NULL, NULL, NULL, (PVOID*)&data, &dataLen) 
+                NULL, NULL, NULL, (PVOID*)&data, &dataLen)
                 && data != NULL && dataLen != 0) {
                 // try to tamper the central part of the packet,
                 // since common packets put their checksum at head or tail
@@ -117,6 +117,10 @@ static short tamperProcess(PacketNode *head, PacketNode *tail) {
         }
         pac = pac->next;
     }
+
+    // We don't mind when we're next scheduled.
+    *delay = 1000;
+
     return tampered;
 }
 

--- a/src/throttle.c
+++ b/src/throttle.c
@@ -13,10 +13,10 @@ static Ihandle *inboundCheckbox, *outboundCheckbox, *chanceInput, *frameInput, *
 static volatile short throttleEnabled = 0,
     throttleInbound = 1, throttleOutbound = 1,
     chance = 1000, // [0-10000]
-    // time frame in ms, when a throttle start the packets within the time 
+    // time frame in ms, when a throttle start the packets within the time
     // will be queued and sent altogether when time is over
     throttleFrame = TIME_DEFAULT,
-    dropThrottled = 0; 
+    dropThrottled = 0;
 
 static PacketNode throttleHeadNode = {0}, throttleTailNode = {0};
 static PacketNode *bufHead = &throttleHeadNode, *bufTail = &throttleTailNode;
@@ -113,7 +113,7 @@ static void throttleCloseDown(PacketNode *head, PacketNode *tail) {
     endTimePeriod();
 }
 
-static short throttleProcess(PacketNode *head, PacketNode *tail) {
+static short throttleProcess(PacketNode *head, PacketNode *tail, short *delay) {
     short throttled = FALSE;
     UNREFERENCED_PARAMETER(head);
     if (!throttleStartTick) {
@@ -151,6 +151,9 @@ THROTTLE_START:
             }
         }
     }
+
+    // We don't mind when we're next scheduled.
+    *delay = 1000;
 
     return throttled;
 }


### PR DESCRIPTION
The motivation here is that I want to be able to apply quite low amounts of lag, and variation in lag - and in the current code the value of `CLOCK_WAITMS` at 40ms, and the associated `Sleep()`, is high enough to prevent this from being accurate.

Eg if I set lag to 50ms, what I actually see is lag varying from 50-90ms.

So what I've done is this:
- In the first commit on this pull request, simplify the processing so that all interference happens on just one thread
  - the thread that reads packets only reads packets and puts them on the queue - it no longer does any processing.  Instead it just sets an event to signal to the other thread to indicate that there's work to do.
  - that thread wakes up either on timeout or on being signaled, and processes queued packets
- In the second commit, I allow modules to indicate how long a delay they want before being rescheduled, and have the processing thread use a shorter timeout if requested
  - in particular, `lag` now indicates when it would like to be rescheduled to send lagged packets - rather than having to wait and be up to `CLOCK_WAITMS` late

This version of the pull request is against master - if you take #33, then there's a trivial one-line change needed to `lag`s calculation of the delay.  I'd be happy to re-submit this one after #33 is merged, if that's more convenient.