### PR TITLE
Finish speed cap implementation

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -8,7 +8,7 @@
 #define MSG_BUFSIZE 512
 #define FILTER_BUFSIZE 1024
 #define NAME_SIZE 16
-#define MODULE_CNT 7
+#define MODULE_CNT 8
 #define ICON_UPDATE_MS 200
 
 #define CONTROLS_HANDLE "__CONTROLS_HANDLE"
@@ -103,6 +103,7 @@ int uiSyncChance(Ihandle *ih);
 int uiSyncToggle(Ihandle *ih, int state);
 int uiSyncInteger(Ihandle *ih);
 int uiSyncFixed(Ihandle *ih);
+int uiSyncFixedInt(Ihandle *ih);
 
 
 // module

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ Module* modules[MODULE_CNT] = {
     &oodModule,
     &tamperModule,
     &resetModule,
-    //&capModule
+    &capModule
 };
 
 volatile short sendState = SEND_STATUS_NONE;

--- a/src/utils.c
+++ b/src/utils.c
@@ -104,6 +104,31 @@ int uiSyncFixed(Ihandle *ih) {
     return IUP_DEFAULT;
 }
 
+int uiSyncFixedInt(Ihandle *ih) {
+    long *fixedPointer = (long*)IupGetAttribute(ih, SYNCED_VALUE);
+    const float maxFixedValue = IupGetFloat(ih, FIXED_MAX);
+    const float minFixedValue = IupGetFloat(ih, FIXED_MIN);
+    float value = IupGetFloat(ih, "VALUE");
+    float newValue = value;
+    long fixValue;
+    char valueBuf[8];
+    if (newValue > maxFixedValue) {
+        newValue = maxFixedValue;
+    } else if (newValue < minFixedValue) {
+        newValue = minFixedValue;
+    }
+
+    if (newValue != value && value != 0) {
+        sprintf(valueBuf, "%.2f", newValue);
+        IupStoreAttribute(ih, "VALUE", valueBuf);
+        // put caret at end to enable editing while normalizing
+        IupStoreAttribute(ih, "CARET", "10");
+    }
+    // sync back
+    fixValue = (long)(newValue / FIXED_EPSILON);
+    InterlockedExchange(fixedPointer, fixValue);
+    return IUP_DEFAULT;
+}
 
 // indicator icon, generated from scripts/im2carr.py
 const unsigned char icon8x8[8*8] = {


### PR DESCRIPTION
Changed the speed cap max to 2GB. For that I added the uiSyncFixedInt function to utils.c

Fixed the implementation for the buffer so it is maxed at both number of messages and size of the buffer, to avoid bufferbloating. The macro ALLOW_SET_BUFFER_SIZE can be set to allow the user to select the size of the buffer. If left unchecked, a quarter of the speed per second is used (as per common practices).

The buffering/dropping was done for both inbound and outbound packets once it had started. Changed to a packet per packet model to allow for only one direction capping.

Fixed a crash when dropping packets because they weren't popped from the list.