### PR TITLE
Fix typo in download page

### DIFF
--- a/download.html
+++ b/download.html
@@ -36,7 +36,7 @@
         <ul class="textlist">
             <li>32bit: <a href="https://github.com/jagt/clumsy/releases/download/0.3/clumsy-0.3-win32-a.zip">clumsy-0.3-win32-a.zip</a></li>
             <li>64bit: <a href="https://github.com/jagt/clumsy/releases/download/0.3/clumsy-0.3-win64-a.zip">clumsy-0.3-win64-a.zip</a></li>
-            <il>See other binaries <a href="https://github.com/jagt/clumsy/releases/tag/0.3">here</a>.</il>
+            <il>Or <a href="https://github.com/jagt/clumsy/releases/tag/0.3">see other binaries</a>.</il>
         </ul>
 
         <h4>Install</h4>
@@ -51,7 +51,7 @@
         With 0.3 we've setup clumsy to be built with <a href="https://ziglang.org">Zig</a> and it's how we build the shipping binaries.
 
         <ol>
-            <li>Download a copy of <a href="https://ziglang.org/download/#release-0.9.1">zig 0.9.1 here</a></li>
+            <li>Download a copy of <a href="https://ziglang.org/download/#release-0.9.1">zig 0.9.1</a></li>
             <li>Open <code>build.zig</code> and check that Windows SDK path is correct on your machine.<br> It's hardcoded as <code>C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0</code></li>
             <li>Then you can run the commands below to build:
 

--- a/download.html
+++ b/download.html
@@ -30,7 +30,7 @@
         <h1>Download</h1>
         </div>
         <h4>Releases</h4>
-        <p><strong>Notice: clumsy only support Windows Vista, Windows 7 and above. 64bit Windows users are strongly recommanded to download the 64bit build.</strong></p>
+        <p><strong>Notice: clumsy only support Windows Vista, Windows 7 and above. 64bit Windows users are strongly recommended to download the 64bit build.</strong></p>
 
         <p>0.3</p>
         <ul class="textlist">


### PR DESCRIPTION
Just a thing I noticed. I can drop the second commit if preferred. It's just [a pet peeve of mine and others](https://ddg.gg/why%20here%20links%20bad).