### PR TITLE
Fix RNG seeded on the wrong thread (msvcrt thread-local seed, #94)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -168,6 +168,9 @@ void divertStop();
 #define STR(x) STR_HELPER(x)
 
 short calcChance(short chance);
+// seed the thread-local RNG; must be called once at the start of each worker
+// thread that uses calcChance/rand (see issue #94)
+void seedRand(void);
 
 // inline helper for inbound outbound check
 static INLINE_FUNCTION

--- a/src/divert.c
+++ b/src/divert.c
@@ -242,6 +242,8 @@ static DWORD divertClockLoop(LPVOID arg) {
 
     UNREFERENCED_PARAMETER(arg);
 
+    seedRand(); // rand() seed is thread-local under msvcrt (issue #94)
+
     for(;;) {
         // use acquire as wait for yielding thread
         startTick = GetTickCount();
@@ -327,6 +329,8 @@ static DWORD divertReadLoop(LPVOID arg) {
     DWORD waitResult;
 
     UNREFERENCED_PARAMETER(arg);
+
+    seedRand(); // rand() seed is thread-local under msvcrt (issue #94)
 
     for(;;) {
         // each step must fully consume the list

--- a/src/main.c
+++ b/src/main.c
@@ -261,8 +261,10 @@ void init(int argc, char* argv[]) {
 }
 
 void startup() {
-    // initialize seed
-    srand((unsigned int)time(NULL));
+    // NOTE: rand() is seeded per worker thread via seedRand() in divert.c's
+    // read/clock loops. Seeding here is useless because rand()'s seed is
+    // thread-local under msvcrt and rand() never runs on this (main) thread.
+    // See issue #94.
 
     // kickoff event loops
     IupShowXY(dialog, IUP_CENTER, IUP_CENTER);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <time.h>
 #include <Windows.h>
 #include "iup.h"
 #include "common.h"
@@ -6,6 +7,13 @@
 short calcChance(short chance) {
     // notice that here we made a copy of chance, so even though it's volatile it is still ok
     return (chance == 10000) || ((rand() % 10000) < chance);
+}
+
+void seedRand(void) {
+    // rand()/srand() use a thread-local seed under msvcrt, so each worker thread
+    // that calls rand() (via calcChance) must seed its own. XOR in the thread id
+    // to de-correlate threads seeded within the same second. See issue #94.
+    srand((unsigned int)(time(NULL) ^ ((unsigned int)GetCurrentThreadId() << 16)));
 }
 
 static short resolutionSet = 0;


### PR DESCRIPTION
## Problem

`srand()` is called once in `startup()` on the **main thread**, but `rand()` -- used by every module through `calcChance()` -- runs on the two worker threads created in `divert.c` (`divertReadLoop` / `divertClockLoop`).

Under the Microsoft CRT (msvcrt, which the MinGW/Zig build links), `rand()`'s seed is **thread-local**. The worker threads therefore never see the seed set on the main thread and start from the default seed (`1`). As a result the drop / duplicate / out-of-order / throttle / reset probabilities are:

- deterministic across every run, and
- identical between the read loop and the clock loop.

This is the bug reported in #94.

## Fix

- Add a small helper `seedRand()` in `utils.c` (declared in `common.h`) that does `srand(time(NULL) ^ (GetCurrentThreadId() << 16))`. XOR-ing the thread id de-correlates the two loops, which are otherwise created within the same second.
- Call `seedRand()` once at the top of `divertReadLoop` and `divertClockLoop`.
- Remove the now-useless `srand()` from `startup()` (replaced with an explanatory comment).

No behavioural change other than the RNG now being properly seeded per worker thread.

## Verification

Builds clean with `zig build -Darch=x64 -Dconf=Debug -Dsign=A` (Zig 0.9.1).

Fixes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)